### PR TITLE
Feature/changes and open in default program

### DIFF
--- a/Findin/FileMatchInformation.cs
+++ b/Findin/FileMatchInformation.cs
@@ -1,2 +1,3 @@
 ﻿namespace Findin;
+
 internal record FileMatchInformation(string FileName, int LineNumber, string LineContent);

--- a/Findin/FormState.cs
+++ b/Findin/FormState.cs
@@ -4,6 +4,5 @@
         string Path, 
         string FilePatterns, 
         string Search, 
-        string DefaultProgramPath,
         string IgnoredDirectories);
 }

--- a/Findin/MainWindow.Designer.cs
+++ b/Findin/MainWindow.Designer.cs
@@ -114,7 +114,7 @@
             this.button1.Name = "button1";
             this.button1.Size = new System.Drawing.Size(223, 23);
             this.button1.TabIndex = 1;
-            this.button1.Text = "Select Folder";
+            this.button1.Text = "Select Directory";
             this.button1.UseVisualStyleBackColor = true;
             this.button1.Click += new System.EventHandler(this.SelectFolderButton_Click);
             // 
@@ -157,9 +157,9 @@
             // 
             // ResultListView
             // 
-            this.ResultListView.Location = new System.Drawing.Point(12, 160);
+            this.ResultListView.Location = new System.Drawing.Point(12, 149);
             this.ResultListView.Name = "ResultListView";
-            this.ResultListView.Size = new System.Drawing.Size(1505, 469);
+            this.ResultListView.Size = new System.Drawing.Size(1505, 480);
             this.ResultListView.TabIndex = 11;
             this.ResultListView.UseCompatibleStateImageBehavior = false;
             // 

--- a/Findin/MainWindow.cs
+++ b/Findin/MainWindow.cs
@@ -304,9 +304,7 @@ namespace Findin
 
             ContextMenuStrip = new();
 
-            AddToolStripMenuItemToContextMenuStrip("Copy File Name", CopyFileNameToClipboard_Click);
-            AddToolStripMenuItemToContextMenuStrip("Copy Line Number", CopyLineNumberToClipboard_Click);
-            AddToolStripMenuItemToContextMenuStrip("Copy Line Content", CopyLineContentToClipboard_Click);
+            AddToolStripMenuItemToContextMenuStrip("Copy File Path", CopyFilePathToClipboard_Click);
             AddToolStripMenuItemToContextMenuStrip("Copy Formatted", CopyFormattedContentToClipboard_Click);
 
             if (!File.Exists(FormStateFileName))
@@ -334,24 +332,12 @@ namespace Findin
             ContextMenuStrip.Items.Add(menuItem);
         }
 
-        private void CopyFileNameToClipboard_Click(object? sender, EventArgs e)
+        private void CopyFilePathToClipboard_Click(object? sender, EventArgs e)
         {
             if (ResultListView.SelectedItems.Count > 0)
                 Clipboard.SetText(
-                    ResultListView.SelectedItems[0].SubItems[0]?.Text?.Split("\\")[^1] ?? string.Empty
+                    ResultListView.SelectedItems[0].SubItems[0]?.Text ?? string.Empty
                     );
-        }
-
-        private void CopyLineNumberToClipboard_Click(object? sender, EventArgs e)
-        {
-            if (ResultListView.SelectedItems.Count > 0)
-                Clipboard.SetText(ResultListView.SelectedItems[0].SubItems[1]?.Text ?? string.Empty);
-        }
-
-        private void CopyLineContentToClipboard_Click(object? sender, EventArgs e)
-        {
-            if (ResultListView.SelectedItems.Count > 0)
-                Clipboard.SetText(ResultListView.SelectedItems[0].SubItems[2]?.Text ?? string.Empty);
         }
 
         private void CopyFormattedContentToClipboard_Click(object? sender, EventArgs e)
@@ -361,10 +347,10 @@ namespace Findin
             
             ListViewItem selectedItem = ResultListView.SelectedItems[0];
 
-            string formattedCopyContent = 
-                string.Format(CopiedLineFormat, 
-                    selectedItem.SubItems[0]?.Text?.Split("\\")[^1], 
-                    selectedItem.SubItems[1].Text, 
+            string formattedCopyContent =
+                string.Format(CopiedLineFormat,
+                    selectedItem.SubItems[0]?.Text,
+                    selectedItem.SubItems[1].Text,
                     selectedItem.SubItems[2].Text
                 );
 


### PR DESCRIPTION
### This pull request includes:

- Removal of "not-so-used" features such as Copy Line, Copy Line Content and Copy File Name, being replaced by two new (although "Copy Formatted" is still here):

- **Copy File Path**: Allows the user to copy the full file path instead of only the name of the file; and 
- **Open In {program}**: This new feature allows the user to configure a file called `config_editor.txt` with information such as command line arguments and name of the program, so when clicking the option in the context menu, their favorite text editor will open.

New tests and `README.md` update will be included in the next pull request.